### PR TITLE
Make the binary URL configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+sd_binary_url: "https://github.com/skydive-project/skydive/releases/download/v0.3.0/skydive"
 from_sources: False
 sd_service_type: agent
 sd_ws_pong_timeout: 5

--- a/tasks/from_binary.yml
+++ b/tasks/from_binary.yml
@@ -2,6 +2,6 @@
 # At this time (11/07/2016) there's still some bugs with binary (ex: "skydive agent" doesn't handle SIGTERM). Better to build from sources ;)
 - name: Download binary from https://github.com/skydive-project/
   get_url:
-    url: "{{ skydive_binary_url }}"
+    url: "{{ sd_binary_url }}"
     dest: "/usr/local/bin/skydive"
     mode: 0755

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,2 @@
 ---
-skydive_binary_url: "https://github.com/skydive-project/skydive/releases/download/v0.3.0/skydive"
 redhat_go_dir: "{{ env_gopath.stdout }}/src/github.com/redhat-cip"


### PR DESCRIPTION
Custom builds can be done once and shared on all the machines. It's also
possible to have a local copy of the official binary and avoid multiple
downloads.
